### PR TITLE
fix: Only remove specific record on cleanup instead of entire RRSet

### DIFF
--- a/pkg/hetzner/hcloud.go
+++ b/pkg/hetzner/hcloud.go
@@ -3,6 +3,7 @@ package hetzner
 import (
 	"fmt"
 	"runtime/debug"
+	"strconv"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 
@@ -52,4 +53,11 @@ func RRSetTypeFromString(rType string) (hcloud.ZoneRRSetType, error) {
 	default:
 		return "", fmt.Errorf("unrecognized resource record set type %s", rType)
 	}
+}
+
+func QuoteIfRequired(val string, rrSetType hcloud.ZoneRRSetType) string {
+	if rrSetType == hcloud.ZoneRRSetTypeTXT {
+		return strconv.Quote(val)
+	}
+	return val
 }

--- a/pkg/middleware/bind.go
+++ b/pkg/middleware/bind.go
@@ -138,7 +138,7 @@ func BindHTTPReq(next http.Handler) http.Handler {
 			return
 		}
 
-		if r.URL.Path == "/httpreq/present" && d.Value == "" {
+		if d.Value == "" {
 			http.Error(w, "value is missing", http.StatusBadRequest)
 			return
 		}

--- a/pkg/middleware/clean/cloud/cloud.go
+++ b/pkg/middleware/clean/cloud/cloud.go
@@ -46,7 +46,7 @@ func (u *cleaner) Clean(ctx context.Context, reqData *data.ReqData) error {
 	}
 
 	action, _, err := u.client.Zone.RemoveRRSetRecords(ctx, rrSet, hcloud.ZoneRRSetRemoveRecordsOpts{
-		Records: rrSet.Records,
+		Records: []hcloud.ZoneRRSetRecord{{Value: hetzner.QuoteIfRequired(reqData.Value, rrSetType)}},
 	})
 	if err != nil {
 		return err

--- a/pkg/middleware/update/cloud/cloud.go
+++ b/pkg/middleware/update/cloud/cloud.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"context"
-	"strconv"
 	"sync"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -69,7 +68,7 @@ func (u *updater) updateRRSet(ctx context.Context, rrSet *hcloud.ZoneRRSet, val 
 
 	opts := hcloud.ZoneRRSetSetRecordsOpts{
 		Records: []hcloud.ZoneRRSetRecord{{
-			Value: quoteIfRequired(val, rrSet.Type),
+			Value: hetzner.QuoteIfRequired(val, rrSet.Type),
 		}},
 	}
 	action, _, err := u.client.Zone.SetRRSetRecords(ctx, rrSet, opts)
@@ -89,7 +88,7 @@ func (u *updater) createRRSet(ctx context.Context, zone *hcloud.Zone, rrSetType 
 		Type: rrSetType,
 		TTL:  &u.cfg.RecordTTL,
 		Records: []hcloud.ZoneRRSetRecord{{
-			Value: quoteIfRequired(val, rrSetType),
+			Value: hetzner.QuoteIfRequired(val, rrSetType),
 		}},
 	}
 	result, _, err := u.client.Zone.CreateRRSet(ctx, zone, opts)
@@ -101,11 +100,4 @@ func (u *updater) createRRSet(ctx context.Context, zone *hcloud.Zone, rrSetType 
 	}
 
 	return nil
-}
-
-func quoteIfRequired(val string, rrSetType hcloud.ZoneRRSetType) string {
-	if rrSetType == hcloud.ZoneRRSetTypeTXT {
-		return strconv.Quote(val)
-	}
-	return val
 }

--- a/tests/httpreq_test.go
+++ b/tests/httpreq_test.go
@@ -6,10 +6,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 
 	"github.com/0xfelix/hetzner-dnsapi-proxy/tests/libcloudapi"
 	"github.com/0xfelix/hetzner-dnsapi-proxy/tests/libserver"
@@ -80,15 +83,19 @@ var _ = Describe("HTTPReq", func() {
 		DescribeTable("cleaning up", func(ctx context.Context, fqdn string) {
 			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
 
+			rrSet := libcloudapi.ExistingRRSetTXT()
 			api.AppendHandlers(
 				libcloudapi.GetZone(token, libcloudapi.Zone()),
-				libcloudapi.GetRRSet(token, libcloudapi.Zone(), libcloudapi.ExistingRRSetTXT(), true),
-				libcloudapi.RemoveRRSetRecords(token, libcloudapi.Zone(), libcloudapi.ExistingRRSetTXT()),
+				libcloudapi.GetRRSet(token, libcloudapi.Zone(), rrSet, true),
+				libcloudapi.RemoveRRSetRecords(token, libcloudapi.Zone(), rrSet, []schema.ZoneRRSetRecord{
+					{Value: strconv.Quote(libserver.TXTExisting)},
+				}),
 			)
 
 			Expect(doHTTPReqRequest(ctx, server.URL+"/httpreq/cleanup", username, password,
 				map[string]string{
-					"fqdn": fqdn,
+					"fqdn":  fqdn,
+					"value": libserver.TXTExisting,
 				},
 			)).To(Equal(http.StatusOK))
 			Expect(api.ReceivedRequests()).To(HaveLen(3))

--- a/tests/libcloudapi/libcloudapi.go
+++ b/tests/libcloudapi/libcloudapi.go
@@ -65,6 +65,19 @@ func ExistingRRSetTXT() schema.ZoneRRSet {
 	}
 }
 
+func ClientIPRRSetA() schema.ZoneRRSet {
+	return schema.ZoneRRSet{
+		ID:   libserver.ARecordName + "/" + libserver.RecordTypeA,
+		Name: libserver.ARecordName,
+		Type: libserver.RecordTypeA,
+		TTL:  ptr(libserver.DefaultTTL),
+		Records: []schema.ZoneRRSetRecord{
+			{Value: libserver.AExisting},
+		},
+		Zone: mustParseInt(libserver.ZoneID),
+	}
+}
+
 func NewRRSetA() schema.ZoneRRSet {
 	return schema.ZoneRRSet{
 		Name: libserver.ARecordName,
@@ -199,14 +212,14 @@ func SetRRSetRecords(token string, zone schema.Zone, rrSet schema.ZoneRRSet) htt
 	)
 }
 
-func RemoveRRSetRecords(token string, zone schema.Zone, rrSet schema.ZoneRRSet) http.HandlerFunc {
+func RemoveRRSetRecords(token string, zone schema.Zone, rrSet schema.ZoneRRSet, records []schema.ZoneRRSetRecord) http.HandlerFunc {
 	return ghttp.CombineHandlers(
 		ghttp.VerifyRequest(http.MethodPost, fmt.Sprintf("/v1/zones/%d/rrsets/%s/%s/actions/remove_records", zone.ID, rrSet.Name, rrSet.Type)),
 		ghttp.VerifyHeader(http.Header{
 			headerAuthorization: []string{authBearerPrefix + token},
 		}),
 		ghttp.VerifyJSONRepresenting(schema.ZoneRRSetRemoveRecordsRequest{
-			Records: rrSet.Records,
+			Records: records,
 		}),
 		getResponseSuccess(),
 	)


### PR DESCRIPTION
## Summary
- Only removes the specific record matching the request value on `/httpreq/cleanup` instead of nuking the entire RRSet
- Makes `value` required on `/httpreq/cleanup` so the contract is explicit (no fallback to deleting all records)
- Extracts `QuoteIfRequired` to `pkg/hetzner` so clean and update paths share TXT quoting

## Test plan
- [x] `make fmt`
- [x] `make lint`
- [x] `make build`
- [x] `make functest`