### PR TITLE
feat: Add /nic/update endpoint for DynDNS2 protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Get the container image from [ghcr.io](https://github.com/0xFelix/hetzner-dnsapi
 | ACMEDNS            | POST `/acmedns/update`<br>(see https://github.com/joohoi/acme-dns#update-endpoint)                                                                                                                                                                                 |
 | DirectAdmin Legacy | GET `/directadmin/CMD_API_SHOW_DOMAINS`<br>GET `/directadmin/CMD_API_DNS_CONTROL` (only adding A/AAAA/TXT records, everything else always returns `200 OK`)<br>GET `/directadmin/CMD_API_DOMAIN_POINTER` (only a stub, always returns `200 OK`)<br>(see https://docs.directadmin.com/developer/api/legacy-api.html and https://www.directadmin.com/features.php?id=504) |
 | plain HTTP         | GET `/plain/update` (query params `hostname` and `ip` (can be ipv4 for A or ipv6 for AAAA records), if auth method is `users` then HTTP Basic auth is used) <br/>                                                                                                                                                                                                               |
+| DynDNS2            | GET `/nic/update` (query params `hostname` and optional `myip` (falls back to client IP, ipv4 or ipv6), HTTP Basic auth, responses follow the DynDNS2 token spec)                                                                                                                                                                                                             |
 
 ## Configuration
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -34,6 +34,8 @@ func New(cfg *config.Config) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("GET /plain/update",
 		handle(cfg, middleware.BindPlain, authorizer, updater, middleware.StatusOk))
+	mux.Handle("GET /nic/update",
+		handle(cfg, middleware.BindNicUpdate, middleware.NicAuth(cfg), middleware.NicUpdate(updater), middleware.StatusOkNicUpdate))
 	mux.Handle("POST /acmedns/update",
 		handle(cfg, middleware.BindAcmeDNS, authorizer, updater, middleware.StatusOkAcmeDNS))
 	mux.Handle("POST /httpreq/present",

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -23,12 +23,7 @@ func NewAuthorizer(cfg *config.Config) func(http.Handler) http.Handler {
 			}
 
 			if !CheckPermission(cfg, reqData, r.RemoteAddr) {
-				addr := sanitize.LogValue(r.RemoteAddr)
-				typ := sanitize.LogValue(reqData.Type)
-				name := sanitize.LogValue(reqData.FullName)
-				val := sanitize.LogValue(reqData.Value)
-				//nolint:gosec // values are sanitized above
-				log.Printf("client '%s' is not allowed to update '%s' data of '%s' to '%s'", addr, typ, name, val)
+				logPermissionDenied(r.RemoteAddr, reqData)
 				if cfg.Auth.Method != config.AuthMethodAllowedDomains && reqData.BasicAuth {
 					w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 				}
@@ -39,6 +34,15 @@ func NewAuthorizer(cfg *config.Config) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func logPermissionDenied(remoteAddr string, reqData *data.ReqData) {
+	addr := sanitize.LogValue(remoteAddr)
+	typ := sanitize.LogValue(reqData.Type)
+	name := sanitize.LogValue(reqData.FullName)
+	val := sanitize.LogValue(reqData.Value)
+	//nolint:gosec // values are sanitized above
+	log.Printf("client '%s' is not allowed to update '%s' data of '%s' to '%s'", addr, typ, name, val)
 }
 
 func CheckPermission(cfg *config.Config, reqData *data.ReqData, remoteAddr string) bool {

--- a/pkg/middleware/nicupdate.go
+++ b/pkg/middleware/nicupdate.go
@@ -1,0 +1,186 @@
+package middleware
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/config"
+	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/data"
+)
+
+const (
+	nicTokenGood    = "good"
+	nicTokenNotFQDN = "notfqdn"
+	nicTokenBadAuth = "badauth"
+	nicTokenNoHost  = "nohost"
+	nicTokenDNSErr  = "dnserr"
+	nicToken911     = "911"
+	textPlainUTF8   = "text/plain; charset=utf-8"
+)
+
+func BindNicUpdate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+		if err := r.ParseForm(); err != nil {
+			log.Printf(failedParseRequestFmt, err)
+			writeNicToken(w, http.StatusOK, nicTokenNotFQDN)
+			return
+		}
+
+		hostname := r.Form.Get("hostname")
+		if hostname == "" {
+			writeNicToken(w, http.StatusOK, nicTokenNotFQDN)
+			return
+		}
+
+		ip := r.Form.Get("myip")
+		if ip == "" {
+			ip = r.RemoteAddr
+		}
+
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			writeNicToken(w, http.StatusOK, nicTokenNotFQDN)
+			return
+		}
+
+		recordType := recordTypeA
+		if parsedIP.To4() == nil {
+			recordType = recordTypeAAAA
+		}
+
+		name, zone, err := SplitFQDN(hostname)
+		if err != nil {
+			writeNicToken(w, http.StatusOK, nicTokenNotFQDN)
+			return
+		}
+
+		username, password, _ := r.BasicAuth()
+		next.ServeHTTP(w, r.WithContext(
+			data.NewContextWithReqData(r.Context(),
+				&data.ReqData{
+					FullName:  hostname,
+					Name:      name,
+					Zone:      zone,
+					Value:     ip,
+					Type:      recordType,
+					Username:  username,
+					Password:  password,
+					BasicAuth: true,
+				},
+			)),
+		)
+	})
+}
+
+func NicAuth(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqData, err := data.ReqDataFromContext(r.Context())
+			if err != nil {
+				log.Printf("%v", err)
+				writeNicToken(w, http.StatusOK, nicToken911)
+				return
+			}
+
+			if CheckPermission(cfg, reqData, r.RemoteAddr) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			logPermissionDenied(r.RemoteAddr, reqData)
+			if isBadAuth(cfg, reqData) {
+				w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+				writeNicToken(w, http.StatusUnauthorized, nicTokenBadAuth)
+				return
+			}
+			writeNicToken(w, http.StatusOK, nicTokenNoHost)
+		})
+	}
+}
+
+func isBadAuth(cfg *config.Config, reqData *data.ReqData) bool {
+	switch cfg.Auth.Method {
+	case config.AuthMethodUsers, config.AuthMethodBoth, config.AuthMethodAny:
+		return !checkUserCredentials(reqData.Username, reqData.Password, cfg.Auth.Users)
+	}
+	return false
+}
+
+func checkUserCredentials(username, password string, users []config.User) bool {
+	if username == "" || password == "" {
+		return false
+	}
+	for _, user := range users {
+		if user.Username == username && user.Password == password {
+			return true
+		}
+	}
+	return false
+}
+
+func NicUpdate(updater func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		inner := updater(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			inner.ServeHTTP(&nicErrorWriter{
+				ResponseWriter: w,
+				mapStatus: func(int) (int, string) {
+					return http.StatusOK, nicTokenDNSErr
+				},
+			}, r)
+		})
+	}
+}
+
+func StatusOkNicUpdate(_ http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqData, err := data.ReqDataFromContext(r.Context())
+		if err != nil {
+			log.Printf("%v", err)
+			writeNicToken(w, http.StatusOK, nicTokenDNSErr)
+			return
+		}
+		writeNicToken(w, http.StatusOK, nicTokenGood+" "+reqData.Value)
+	})
+}
+
+func writeNicToken(w http.ResponseWriter, status int, token string) {
+	w.Header().Set(headerContentType, textPlainUTF8)
+	w.WriteHeader(status)
+	if _, err := fmt.Fprint(w, token); err != nil {
+		log.Printf(failedWriteResponseFmt, err)
+	}
+}
+
+type nicErrorWriter struct {
+	http.ResponseWriter
+	mapStatus func(code int) (int, string)
+	handled   bool
+}
+
+func (w *nicErrorWriter) WriteHeader(code int) {
+	if w.handled {
+		return
+	}
+	if code == http.StatusOK {
+		w.ResponseWriter.WriteHeader(code)
+		return
+	}
+	w.handled = true
+	status, token := w.mapStatus(code)
+	w.ResponseWriter.Header().Set(headerContentType, textPlainUTF8)
+	w.ResponseWriter.WriteHeader(status)
+	if _, err := fmt.Fprint(w.ResponseWriter, token); err != nil {
+		log.Printf(failedWriteResponseFmt, err)
+	}
+}
+
+func (w *nicErrorWriter) Write(b []byte) (int, error) {
+	if w.handled {
+		return len(b), nil
+	}
+	return w.ResponseWriter.Write(b)
+}

--- a/tests/libcloudapi/libcloudapi.go
+++ b/tests/libcloudapi/libcloudapi.go
@@ -65,6 +65,19 @@ func ExistingRRSetTXT() schema.ZoneRRSet {
 	}
 }
 
+func ClientIPRRSetA() schema.ZoneRRSet {
+	return schema.ZoneRRSet{
+		ID:   libserver.ARecordName + "/" + libserver.RecordTypeA,
+		Name: libserver.ARecordName,
+		Type: libserver.RecordTypeA,
+		TTL:  ptr(libserver.DefaultTTL),
+		Records: []schema.ZoneRRSetRecord{
+			{Value: libserver.AExisting},
+		},
+		Zone: mustParseInt(libserver.ZoneID),
+	}
+}
+
 func NewRRSetA() schema.ZoneRRSet {
 	return schema.ZoneRRSet{
 		Name: libserver.ARecordName,

--- a/tests/nicupdate_test.go
+++ b/tests/nicupdate_test.go
@@ -1,0 +1,205 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/0xfelix/hetzner-dnsapi-proxy/tests/libcloudapi"
+	"github.com/0xfelix/hetzner-dnsapi-proxy/tests/libserver"
+)
+
+var _ = Describe("NicUpdate", func() {
+	var (
+		api      *ghttp.Server
+		server   *httptest.Server
+		token    string
+		username string
+		password string
+	)
+
+	BeforeEach(func() {
+		api = ghttp.NewServer()
+	})
+
+	AfterEach(func() {
+		server.Close()
+		api.Close()
+	})
+
+	Context("should succeed", func() {
+		//nolint:dupl
+		It("creating a new record", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+
+			api.AppendHandlers(
+				libcloudapi.GetZone(token, libcloudapi.Zone()),
+				libcloudapi.GetRRSet(token, libcloudapi.Zone(), libcloudapi.NewRRSetA(), false),
+				libcloudapi.CreateRRSet(token, libcloudapi.Zone(), libcloudapi.NewRRSetA()),
+			)
+
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.ARecordNameFull},
+				"myip":     []string{libserver.AUpdated},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("good " + libserver.AUpdated))
+			Expect(api.ReceivedRequests()).To(HaveLen(3))
+		})
+
+		//nolint:dupl
+		It("creating a new AAAA record", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+
+			api.AppendHandlers(
+				libcloudapi.GetZone(token, libcloudapi.Zone()),
+				libcloudapi.GetRRSet(token, libcloudapi.Zone(), libcloudapi.NewRRSetAAAA(), false),
+				libcloudapi.CreateRRSet(token, libcloudapi.Zone(), libcloudapi.NewRRSetAAAA()),
+			)
+
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.AAAARecordNameFull},
+				"myip":     []string{libserver.AAAAUpdated},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("good " + libserver.AAAAUpdated))
+			Expect(api.ReceivedRequests()).To(HaveLen(3))
+		})
+
+		//nolint:dupl
+		It("updating an existing record", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+
+			api.AppendHandlers(
+				libcloudapi.GetZone(token, libcloudapi.Zone()),
+				libcloudapi.GetRRSet(token, libcloudapi.Zone(), libcloudapi.ExistingRRSetA(), true),
+				libcloudapi.ChangeRRSetTTL(token, libcloudapi.Zone(), libcloudapi.UpdatedRRSetA()),
+				libcloudapi.SetRRSetRecords(token, libcloudapi.Zone(), libcloudapi.UpdatedRRSetA()),
+			)
+
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.ARecordNameFull},
+				"myip":     []string{libserver.AUpdated},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("good " + libserver.AUpdated))
+			Expect(api.ReceivedRequests()).To(HaveLen(4))
+		})
+
+		//nolint:dupl
+		It("updating an existing AAAA record", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+
+			api.AppendHandlers(
+				libcloudapi.GetZone(token, libcloudapi.Zone()),
+				libcloudapi.GetRRSet(token, libcloudapi.Zone(), libcloudapi.ExistingRRSetAAAA(), true),
+				libcloudapi.ChangeRRSetTTL(token, libcloudapi.Zone(), libcloudapi.UpdatedRRSetAAAA()),
+				libcloudapi.SetRRSetRecords(token, libcloudapi.Zone(), libcloudapi.UpdatedRRSetAAAA()),
+			)
+
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.AAAARecordNameFull},
+				"myip":     []string{libserver.AAAAUpdated},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("good " + libserver.AAAAUpdated))
+			Expect(api.ReceivedRequests()).To(HaveLen(4))
+		})
+
+		It("using client ip when myip is omitted", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+
+			api.AppendHandlers(
+				libcloudapi.GetZone(token, libcloudapi.Zone()),
+				libcloudapi.GetRRSet(token, libcloudapi.Zone(), libcloudapi.ExistingRRSetA(), true),
+				libcloudapi.ChangeRRSetTTL(token, libcloudapi.Zone(), libcloudapi.ClientIPRRSetA()),
+				libcloudapi.SetRRSetRecords(token, libcloudapi.Zone(), libcloudapi.ClientIPRRSetA()),
+			)
+
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.ARecordNameFull},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("good " + libserver.AExisting))
+			Expect(api.ReceivedRequests()).To(HaveLen(4))
+		})
+	})
+
+	Context("should make no api calls and return a DynDNS2 error token", func() {
+		AfterEach(func() {
+			Expect(api.ReceivedRequests()).To(BeEmpty())
+		})
+
+		It("notfqdn when hostname is missing", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"myip": []string{libserver.AUpdated},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("notfqdn"))
+		})
+
+		It("notfqdn when myip is invalid", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.ARecordNameFull},
+				"myip":     []string{"invalid"},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("notfqdn"))
+		})
+
+		It("notfqdn when hostname is malformed", func(ctx context.Context) {
+			server, token, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.TLD},
+				"myip":     []string{libserver.AUpdated},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("notfqdn"))
+		})
+
+		It("nohost when ip-only auth denies access", func(ctx context.Context) {
+			server = libserver.NewNoAllowedDomains(api.URL())
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username, password, url.Values{
+				"hostname": []string{libserver.ARecordNameFull},
+				"myip":     []string{libserver.AUpdated},
+			})
+			Expect(status).To(Equal(http.StatusOK))
+			Expect(body).To(Equal("nohost"))
+		})
+
+		It("badauth when credentials are invalid", func(ctx context.Context) {
+			server, _, username, password = libserver.New(api.URL(), libserver.DefaultTTL)
+			status, body := doNicRequest(ctx, server.URL+"/nic/update", username+"x", password,
+				url.Values{
+					"hostname": []string{libserver.ARecordNameFull},
+					"myip":     []string{libserver.AUpdated},
+				})
+			Expect(status).To(Equal(http.StatusUnauthorized))
+			Expect(body).To(Equal("badauth"))
+		})
+	})
+})
+
+func doNicRequest(ctx context.Context, serverURL, username, password string, data url.Values) (status int, body string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL, http.NoBody)
+	Expect(err).ToNot(HaveOccurred())
+	req.URL.RawQuery = data.Encode()
+	req.SetBasicAuth(username, password)
+
+	c := &http.Client{}
+	res, err := c.Do(req)
+	Expect(err).ToNot(HaveOccurred())
+	b, err := io.ReadAll(res.Body)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(res.Body.Close()).To(Succeed())
+
+	return res.StatusCode, string(b)
+}


### PR DESCRIPTION
## Summary
- Adds DynDNS2-compatible `/nic/update` endpoint (GET `hostname`/`myip` with Basic Auth; falls back to client IP when `myip` is omitted)
- Responses follow the spec: `good <ip>` on success, `notfqdn` / `badauth` / `dnserr` for errors, all `text/plain; charset=utf-8`
- Validation errors are written directly from `BindNicUpdate`; auth/update errors are translated by small `NicAuth` / `NicUpdate` wrappers around the shared authorizer/updater so error handling is not duplicated

## Test plan
- [x] `make fmt`
- [x] `make lint`
- [x] `make build`
- [x] `make functest` (includes new tests that assert both status code and DynDNS2 token body)