### PR TITLE
fix: Use constant-time comparison for Basic Auth credentials

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"log"
 	"net"
 	"net/http"
@@ -91,16 +92,22 @@ func CheckUsers(fqdn, username, password string, users []config.User) bool {
 	if fqdn == "" || username == "" || password == "" {
 		return false
 	}
+	allowed := 0
 	for _, user := range users {
-		if user.Username == username && user.Password == password {
-			for _, domain := range user.Domains {
-				if fqdn == domain || IsSubDomain(fqdn, domain) {
-					return true
-				}
+		credsMatch := constantTimeEqual(user.Username, username) & constantTimeEqual(user.Password, password)
+		domainMatch := 0
+		for _, domain := range user.Domains {
+			if fqdn == domain || IsSubDomain(fqdn, domain) {
+				domainMatch = 1
 			}
 		}
+		allowed |= credsMatch & domainMatch
 	}
-	return false
+	return allowed == 1
+}
+
+func constantTimeEqual(a, b string) int {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b))
 }
 
 func IsSubDomain(sub, parent string) bool {

--- a/pkg/middleware/nicupdate.go
+++ b/pkg/middleware/nicupdate.go
@@ -113,12 +113,11 @@ func checkUserCredentials(username, password string, users []config.User) bool {
 	if username == "" || password == "" {
 		return false
 	}
+	matched := 0
 	for _, user := range users {
-		if user.Username == username && user.Password == password {
-			return true
-		}
+		matched |= constantTimeEqual(user.Username, username) & constantTimeEqual(user.Password, password)
 	}
-	return false
+	return matched == 1
 }
 
 func NicUpdate(updater func(http.Handler) http.Handler) func(http.Handler) http.Handler {


### PR DESCRIPTION
## Summary
- Both \`CheckUsers\` and \`checkUserCredentials\` compared submitted credentials against the configured users with plain \`==\` and returned early on the first match. That leaked timing information twice: Go's string \`==\` short-circuits on the first differing byte (enabling byte-by-byte password discovery), and the early \`return\` revealed the list position of the matching user.
- Replace both with \`crypto/subtle.ConstantTimeCompare\` via a \`constantTimeEqual\` helper, iterate the full user list without early return, and accumulate matches via bitwise OR so every call does the same amount of work regardless of which user (if any) matched.

## Caveats
- \`ConstantTimeCompare\` returns 0 (without full constant-time work) when lengths differ, so username/password lengths themselves still leak. This is usually acceptable; hashing both sides first would fix it but is over-engineering here.

## Test plan
- [x] \`make build && make lint && make functest\` (0 lint issues, 68/68 tests pass)