### PR TITLE
security: Harden server, auth, rate limiting, and proxy config

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ FROM golang:alpine as builder
 
 RUN apk add --update make
 
-RUN adduser --system --shell /bin/false hetzner-dnsapi-proxy
+RUN adduser --system --shell /bin/false --uid 65532 hetzner-dnsapi-proxy
 
 WORKDIR /workspace
 
@@ -25,6 +25,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /workspace/bin/hetzner-dnsapi-proxy /
 
-USER hetzner-dnsapi-proxy
+USER 65532:65532
 EXPOSE 8081
 ENTRYPOINT ["/hetzner-dnsapi-proxy"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Get the container image from [ghcr.io](https://github.com/0xFelix/hetzner-dnsapi
 Configuration can be passed by environment variables or from a file (with 
 the `-c` flag).
 
+> **Security notes:**
+> - The server speaks plaintext HTTP only. Terminate TLS in front of it
+>   (e.g. with a reverse proxy) whenever it is exposed beyond a trusted
+>   network - credentials and update values would otherwise travel in clear
+>   text.
+> - The config file holds the Hetzner API token and, optionally, user
+>   passwords. Restrict it to the service account (e.g. `chmod 600`) and
+>   keep it out of version control and container images.
+
 ### Authorization
 
 Authorization takes place via a list of domains and ip networks allowed
@@ -43,6 +52,23 @@ The supported authorization methods are:
   satisfied
 - `any`: Combination of `allowedDomains` and `users`, **any** of the two must
   be satisfied
+
+To authorize a domain and all of its subdomains, prefix the entry with `*.`
+(for example `*.example.com` matches `example.com`'s subdomains like
+`foo.example.com` and `bar.foo.example.com`). A bare `example.com` entry only
+authorizes that exact name - subdomains will be rejected.
+
+> **Note:** The `/nic/update` endpoint follows the DynDNS2 response spec and
+> returns `200 OK` with a `nohost` token on authorization failure in
+> `allowedDomains` mode (a `401 badauth` is only returned when HTTP Basic auth
+> is actively being used). The `lockout` feature still applies so repeated
+> `nohost` responses from the same client IP eventually trigger a lockout.
+
+> **Note:** Caller-supplied IPs (`myip` on `/nic/update`, `ip` on
+> `/plain/update`, JSON `value` on `/httpreq/*` and `/acmedns/update`) are
+> taken from the request at face value. They are only as trustworthy as the
+> authenticated client submitting them - there is no server-side verification
+> that the value actually belongs to the caller.
 
 ### Rate limiting and auth-failure lockout
 
@@ -104,7 +130,7 @@ debug: false
 | `RECORD_TTL`               | int    | TTL that is set when creating/updating records                                                                                             | N        | 60 seconds                     |
 | `ALLOWED_DOMAINS`          | string | Combination of domains and CIDRs allowed to update them, example:<br>`example1.com,127.0.0.1/32;_acme-challenge.example2.com,127.0.0.1/32` | Y        |                                |
 | `LISTEN_ADDR`              | string | Listen address of hetzner-dnsapi-proxy                                                                                                     | N        | `:8081`                        |
-| `TRUSTED_PROXIES`          | string | List of trusted proxy host addresses separated by comma                                                                                    | N        | Trust all proxies              |
+| `TRUSTED_PROXIES`          | string | Comma-separated list of trusted proxy IPs or CIDR ranges (e.g. `10.0.0.1,192.168.0.0/24`). When empty, `X-Real-Ip` / `X-Forwarded-For` are ignored. | N        | Trust no proxies               |
 | `RATE_LIMIT_RPS`           | float  | Tokens per second refilled per client IP                                                                                                   | N        | `5`                            |
 | `RATE_LIMIT_BURST`         | int    | Maximum burst size per client IP                                                                                                           | N        | `10`                           |
 | `RATE_LIMIT_IDLE_SECONDS`  | int    | Seconds of inactivity before a client's rate limit bucket is removed                                                                       | N        | `600`                          |

--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ func main() {
 func runServer(listenAddr string, handler http.Handler) error {
 	const (
 		readHeaderTimeout = 10
+		readTimeout       = 30
+		writeTimeout      = 30
+		idleTimeout       = 120
 		shutdownTimeout   = 5
 	)
 
@@ -50,6 +53,9 @@ func runServer(listenAddr string, handler http.Handler) error {
 		Addr:              listenAddr,
 		Handler:           handler,
 		ReadHeaderTimeout: readHeaderTimeout * time.Second,
+		ReadTimeout:       readTimeout * time.Second,
+		WriteTimeout:      writeTimeout * time.Second,
+		IdleTimeout:       idleTimeout * time.Second,
 	}
 
 	go func() {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -55,7 +55,7 @@ func New(cfg *config.Config) http.Handler {
 	mux.Handle("POST /httpreq/cleanup",
 		handle(cfg, rl, middleware.ContentTypeJSON, middleware.BindHTTPReq, authorizer, cleaner, middleware.StatusOk))
 	mux.Handle("GET /directadmin/CMD_API_SHOW_DOMAINS",
-		handle(cfg, rl, middleware.NewShowDomainsDirectAdmin(cfg)))
+		handle(cfg, rl, middleware.NewShowDomainsDirectAdmin(cfg, lockout)))
 	mux.Handle("GET /directadmin/CMD_API_DOMAIN_POINTER",
 		handle(cfg, rl, middleware.StatusOk))
 	mux.Handle("GET /directadmin/CMD_API_DNS_CONTROL",
@@ -65,7 +65,7 @@ func New(cfg *config.Config) http.Handler {
 }
 
 func handle(cfg *config.Config, handlers ...func(http.Handler) http.Handler) http.Handler {
-	handlers = slices.Insert(handlers, 0, middleware.NewSetClientIP(cfg.TrustedProxies))
+	handlers = slices.Insert(handlers, 0, middleware.NewSetClientIP(cfg.TrustedProxyPrefixes))
 	if cfg.Debug {
 		handlers = slices.Insert(handlers, 0, middleware.LogDebug)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
@@ -36,16 +37,17 @@ func (out *AllowedDomains) FromString(val string) error {
 }
 
 type Config struct {
-	BaseURL        string    `yaml:"baseURL"`
-	Token          string    `yaml:"token"`
-	Timeout        int       `yaml:"timeout"`
-	Auth           Auth      `yaml:"auth"`
-	RecordTTL      int       `yaml:"recordTTL"`
-	ListenAddr     string    `yaml:"listenAddr"`
-	TrustedProxies []string  `yaml:"trustedProxies"`
-	RateLimit      RateLimit `yaml:"rateLimit"`
-	Lockout        Lockout   `yaml:"lockout"`
-	Debug          bool      `yaml:"debug"`
+	BaseURL              string         `yaml:"baseURL"`
+	Token                string         `yaml:"token"`
+	Timeout              int            `yaml:"timeout"`
+	Auth                 Auth           `yaml:"auth"`
+	RecordTTL            int            `yaml:"recordTTL"`
+	ListenAddr           string         `yaml:"listenAddr"`
+	TrustedProxies       []string       `yaml:"trustedProxies"`
+	TrustedProxyPrefixes []netip.Prefix `yaml:"-"`
+	RateLimit            RateLimit      `yaml:"rateLimit"`
+	Lockout              Lockout        `yaml:"lockout"`
+	Debug                bool           `yaml:"debug"`
 }
 
 type Auth struct {
@@ -157,6 +159,12 @@ func ParseEnv() (*Config, error) {
 		return nil, err
 	}
 
+	prefixes, parseErr := parseTrustedProxies(cfg.TrustedProxies)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	cfg.TrustedProxyPrefixes = prefixes
+
 	setDefaultBaseURL(cfg)
 
 	return cfg, nil
@@ -242,6 +250,11 @@ func ReadFile(path string) (*Config, error) {
 	if err := validateAuth(&cfg.Auth); err != nil {
 		return nil, err
 	}
+	prefixes, parseErr := parseTrustedProxies(cfg.TrustedProxies)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	cfg.TrustedProxyPrefixes = prefixes
 
 	setDefaultIPMask(cfg.Auth.AllowedDomains)
 	setDefaultBaseURL(cfg)
@@ -278,6 +291,29 @@ func validateRateLimit(rl *RateLimit) error {
 	return nil
 }
 
+func parseTrustedProxies(proxies []string) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(proxies))
+	for _, p := range proxies {
+		prefix, err := parseTrustedProxy(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid trustedProxies entry %q: %w", p, err)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes, nil
+}
+
+func parseTrustedProxy(s string) (netip.Prefix, error) {
+	if prefix, err := netip.ParsePrefix(s); err == nil {
+		return prefix.Masked(), nil
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("must be an IP address or CIDR range: %w", err)
+	}
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
 func validateLockout(l *Lockout) error {
 	if l.MaxAttempts <= 0 {
 		return errors.New("lockout.maxAttempts must be > 0")
@@ -305,11 +341,20 @@ func setDefaultBaseURL(c *Config) {
 }
 
 func setDefaultIPMask(allowedDomains AllowedDomains) {
-	const ff = 255
+	const (
+		bitsPerByte = 8
+		ipv4Bits    = net.IPv4len * bitsPerByte
+		ipv6Bits    = net.IPv6len * bitsPerByte
+	)
 	for _, allowedDomain := range allowedDomains {
 		for _, ipNet := range allowedDomain {
-			if len(ipNet.Mask) == 0 {
-				ipNet.Mask = net.IPv4Mask(ff, ff, ff, ff)
+			if len(ipNet.Mask) != 0 {
+				continue
+			}
+			if ipNet.IP.To4() != nil {
+				ipNet.Mask = net.CIDRMask(ipv4Bits, ipv4Bits)
+			} else {
+				ipNet.Mask = net.CIDRMask(ipv6Bits, ipv6Bits)
 			}
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"net"
+	"net/netip"
 	"os"
 	"path"
 
@@ -108,12 +109,18 @@ var _ = Describe("Config", func() {
 	)
 
 	var (
-		allowedDomains config.AllowedDomains
-		trustedProxies []string
+		allowedDomains       config.AllowedDomains
+		trustedProxies       []string
+		trustedProxyPrefixes []netip.Prefix
 	)
 
 	BeforeEach(func() {
 		trustedProxies = []string{"127.0.0.1", "192.168.0.1", "192.168.0.2"}
+		trustedProxyPrefixes = []netip.Prefix{
+			netip.MustParsePrefix("127.0.0.1/32"),
+			netip.MustParsePrefix("192.168.0.1/32"),
+			netip.MustParsePrefix("192.168.0.2/32"),
+		}
 	})
 
 	Context("ParseEnv", func() {
@@ -172,13 +179,27 @@ var _ = Describe("Config", func() {
 			Expect(cfg.RecordTTL).To(Equal(recordTTL))
 			Expect(cfg.ListenAddr).To(Equal(listenAddr))
 			Expect(cfg.TrustedProxies).To(Equal(trustedProxies))
+			Expect(cfg.TrustedProxyPrefixes).To(Equal(trustedProxyPrefixes))
 			Expect(cfg.Debug).To(BeTrue())
+		})
+
+		It("should parse CIDR ranges in TRUSTED_PROXIES", func() {
+			Expect(os.Setenv(envAPIToken, apiToken)).To(Succeed())
+			Expect(os.Setenv(envAllowedDomains, allowedDomainsStr)).To(Succeed())
+			Expect(os.Setenv(envTrustedProxies, "10.0.0.0/8,2001:db8::/32")).To(Succeed())
+
+			cfg, err := config.ParseEnv()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.TrustedProxyPrefixes).To(Equal([]netip.Prefix{
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("2001:db8::/32"),
+			}))
 		})
 
 		DescribeTable("should fail on invalid environment variables", func(setEnv func(), errMsg string) {
 			setEnv()
 			cfg, err := config.ParseEnv()
-			Expect(err).To(MatchError(errMsg))
+			Expect(err).To(MatchError(ContainSubstring(errMsg)))
 			Expect(cfg).To(BeNil())
 		},
 			Entry("API_TOKEN missing", func() {}, "API_TOKEN environment variable not set"),
@@ -199,6 +220,16 @@ var _ = Describe("Config", func() {
 				Expect(os.Setenv(envAllowedDomains, allowedDomainsStr)).To(Succeed())
 				Expect(os.Setenv(envDebug, "something")).To(Succeed())
 			}, "failed to parse DEBUG: strconv.ParseBool: parsing \"something\": invalid syntax"),
+			Entry("TRUSTED_PROXIES contains a hostname", func() {
+				Expect(os.Setenv(envAPIToken, apiToken)).To(Succeed())
+				Expect(os.Setenv(envAllowedDomains, allowedDomainsStr)).To(Succeed())
+				Expect(os.Setenv(envTrustedProxies, "proxy.example.com")).To(Succeed())
+			}, `invalid trustedProxies entry "proxy.example.com": must be an IP address or CIDR range`),
+			Entry("TRUSTED_PROXIES contains an invalid CIDR", func() {
+				Expect(os.Setenv(envAPIToken, apiToken)).To(Succeed())
+				Expect(os.Setenv(envAllowedDomains, allowedDomainsStr)).To(Succeed())
+				Expect(os.Setenv(envTrustedProxies, "10.0.0.0/99")).To(Succeed())
+			}, `invalid trustedProxies entry "10.0.0.0/99": must be an IP address or CIDR range`),
 		)
 	})
 
@@ -261,7 +292,32 @@ var _ = Describe("Config", func() {
 
 			cfgRead, err := config.ReadFile(filePath)
 			Expect(err).ToNot(HaveOccurred())
+			cfg.TrustedProxyPrefixes = trustedProxyPrefixes
 			Expect(cfgRead).To(Equal(cfg))
+		})
+
+		It("should parse CIDR ranges from trustedProxies", func() {
+			cfg := &config.Config{
+				Token: apiToken,
+				Auth: config.Auth{
+					Method:         config.AuthMethodAllowedDomains,
+					AllowedDomains: allowedDomains,
+				},
+				TrustedProxies: []string{"10.0.0.0/8", "2001:db8::/32"},
+				RateLimit:      validRL(),
+				Lockout:        validLO(),
+			}
+
+			data, err := yaml.Marshal(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(os.WriteFile(filePath, data, 0o600)).To(Succeed())
+
+			cfgRead, err := config.ReadFile(filePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfgRead.TrustedProxyPrefixes).To(Equal([]netip.Prefix{
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("2001:db8::/32"),
+			}))
 		})
 
 		It("should set default ip mask", func() {
@@ -290,7 +346,37 @@ var _ = Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfgRead.Auth.AllowedDomains).To(HaveKeyWithValue("*", []*net.IPNet{{
 				IP:   net.IPv4(127, 0, 0, 1),
-				Mask: net.IPv4Mask(255, 255, 255, 255),
+				Mask: net.CIDRMask(32, 32),
+			}}))
+		})
+
+		It("should set default ip mask for IPv6", func() {
+			cfg := &config.Config{
+				Token: apiToken,
+				Auth: config.Auth{
+					Method: config.AuthMethodAllowedDomains,
+					AllowedDomains: config.AllowedDomains{
+						"*": []*net.IPNet{
+							{
+								IP: net.ParseIP("::1"),
+							},
+						},
+					},
+					Users: users,
+				},
+				RateLimit: validRL(),
+				Lockout:   validLO(),
+			}
+
+			data, err := yaml.Marshal(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(os.WriteFile(filePath, data, 0o600)).To(Succeed())
+
+			cfgRead, err := config.ReadFile(filePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfgRead.Auth.AllowedDomains).To(HaveKeyWithValue("*", []*net.IPNet{{
+				IP:   net.ParseIP("::1"),
+				Mask: net.CIDRMask(128, 128),
 			}}))
 		})
 
@@ -300,7 +386,7 @@ var _ = Describe("Config", func() {
 			Expect(os.WriteFile(filePath, data, 0o600)).To(Succeed())
 
 			cfgRead, err := config.ReadFile(filePath)
-			Expect(err).To(MatchError(errMsg))
+			Expect(err).To(MatchError(ContainSubstring(errMsg)))
 			Expect(cfgRead).To(BeNil())
 		},
 			Entry("missing token", func() *config.Config { return &config.Config{} }, "token is required"),
@@ -387,6 +473,21 @@ var _ = Describe("Config", func() {
 					}
 				},
 				"auth.allowedDomains or auth.users cannot both be empty with auth method any",
+			),
+			Entry("trustedProxies entry is a hostname",
+				func() *config.Config {
+					return &config.Config{
+						Token:     apiToken,
+						RateLimit: validRL(),
+						Lockout:   validLO(),
+						Auth: config.Auth{
+							Method:         config.AuthMethodAllowedDomains,
+							AllowedDomains: allowedDomains,
+						},
+						TrustedProxies: []string{"proxy.example.com"},
+					}
+				},
+				`invalid trustedProxies entry "proxy.example.com": must be an IP address or CIDR range`,
 			),
 		)
 

--- a/pkg/middleware/clientip.go
+++ b/pkg/middleware/clientip.go
@@ -4,37 +4,53 @@ import (
 	"log"
 	"net/http"
 	"net/netip"
-	"slices"
 	"strings"
 
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/sanitize"
 )
 
-func NewSetClientIP(trustedProxies []string) func(http.Handler) http.Handler {
+func NewSetClientIP(trustedProxies []netip.Prefix) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			addrPort, err := netip.ParseAddrPort(r.RemoteAddr)
 			if err != nil {
 				addr := sanitize.LogValue(r.RemoteAddr)
-				//nolint:gosec // value is sanitized above
+				//nolint:gosec // addr is sanitized above; err contains no user-controlled data
 				log.Printf("failed to parse remote address %s: %v", addr, err)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 
-			r.RemoteAddr = addrPort.Addr().String()
-			if slices.Contains(trustedProxies, r.RemoteAddr) {
+			remote := addrPort.Addr()
+			r.RemoteAddr = remote.String()
+			if isTrustedProxy(trustedProxies, remote) {
 				ip := r.Header.Get("X-Real-Ip")
 				if ip == "" {
 					ipList := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
 					ip = strings.TrimSpace(ipList[0])
 				}
 				if ip != "" {
-					r.RemoteAddr = ip
+					parsed, err := netip.ParseAddr(ip)
+					if err != nil {
+						sanitized := sanitize.LogValue(ip)
+						//nolint:gosec // sanitized is sanitized above; r.RemoteAddr is already a parsed IP
+						log.Printf("ignoring invalid forwarded client IP %q from proxy %s", sanitized, r.RemoteAddr)
+					} else {
+						r.RemoteAddr = parsed.String()
+					}
 				}
 			}
 
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func isTrustedProxy(prefixes []netip.Prefix, addr netip.Addr) bool {
+	for _, p := range prefixes {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/middleware/clientip_test.go
+++ b/pkg/middleware/clientip_test.go
@@ -1,0 +1,112 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/middleware"
+)
+
+var _ = Describe("SetClientIP", func() {
+	var (
+		captured string
+		inner    http.Handler
+	)
+
+	BeforeEach(func() {
+		captured = ""
+		inner = http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			captured = r.RemoteAddr
+		})
+	})
+
+	run := func(trustedProxies []netip.Prefix, remoteAddr string, headers map[string]string) *httptest.ResponseRecorder {
+		handler := middleware.NewSetClientIP(trustedProxies)(inner)
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		req.RemoteAddr = remoteAddr
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	It("strips the port from a valid address", func() {
+		rec := run(nil, "10.0.0.1:1234", nil)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(captured).To(Equal("10.0.0.1"))
+	})
+
+	It("returns 500 on an unparseable remote address", func() {
+		rec := run(nil, "not-an-address", nil)
+		Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+	})
+
+	It("honors X-Real-Ip from a trusted proxy matched by bare IP", func() {
+		rec := run(
+			[]netip.Prefix{netip.MustParsePrefix("10.0.0.1/32")},
+			"10.0.0.1:1234", map[string]string{"X-Real-Ip": "192.0.2.7"},
+		)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(captured).To(Equal("192.0.2.7"))
+	})
+
+	It("honors X-Real-Ip from a trusted proxy matched by CIDR", func() {
+		rec := run(
+			[]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+			"10.1.2.3:1234", map[string]string{"X-Real-Ip": "192.0.2.7"},
+		)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(captured).To(Equal("192.0.2.7"))
+	})
+
+	It("honors the first X-Forwarded-For entry from a trusted proxy when X-Real-Ip is absent", func() {
+		rec := run(
+			[]netip.Prefix{netip.MustParsePrefix("10.0.0.1/32")},
+			"10.0.0.1:1234", map[string]string{"X-Forwarded-For": "192.0.2.7, 10.0.0.1"},
+		)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(captured).To(Equal("192.0.2.7"))
+	})
+
+	It("ignores forwarded headers from an untrusted proxy", func() {
+		rec := run(nil, "10.0.0.1:1234", map[string]string{"X-Real-Ip": "192.0.2.7"})
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(captured).To(Equal("10.0.0.1"))
+	})
+
+	It("ignores forwarded headers from an IP outside the trusted CIDR", func() {
+		rec := run(
+			[]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+			"11.0.0.1:1234", map[string]string{"X-Real-Ip": "192.0.2.7"},
+		)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(captured).To(Equal("11.0.0.1"))
+	})
+
+	DescribeTable("falls back to the proxy address on an invalid forwarded value",
+		func(header, value string) {
+			rec := run(
+				[]netip.Prefix{netip.MustParsePrefix("10.0.0.1/32")},
+				"10.0.0.1:1234", map[string]string{header: value},
+			)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(captured).To(Equal("10.0.0.1"))
+		},
+		Entry("invalid X-Real-Ip", "X-Real-Ip", "not-an-ip"),
+		Entry("X-Real-Ip with port", "X-Real-Ip", "192.0.2.7:80"),
+		Entry("invalid first X-Forwarded-For", "X-Forwarded-For", "bogus, 192.0.2.7"),
+		Entry("empty first X-Forwarded-For", "X-Forwarded-For", ", 192.0.2.7"),
+	)
+
+	It("normalizes IPv6 addresses", func() {
+		rec := run(nil, "[2001:db8::1]:1234", nil)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(captured).To(Equal("2001:db8::1"))
+	})
+})

--- a/pkg/middleware/domains.go
+++ b/pkg/middleware/domains.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/config"
+	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/ratelimit"
+	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/sanitize"
 )
 
-func NewShowDomainsDirectAdmin(cfg *config.Config) func(http.Handler) http.Handler {
+func NewShowDomainsDirectAdmin(cfg *config.Config, lockout *ratelimit.Lockout) func(http.Handler) http.Handler {
 	return func(_ http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !config.AuthMethodIsValid(cfg.Auth.Method) {
@@ -20,9 +22,36 @@ func NewShowDomainsDirectAdmin(cfg *config.Config) func(http.Handler) http.Handl
 				return
 			}
 
+			if lockout.IsBlocked(r.RemoteAddr) {
+				logLockedOut(r.RemoteAddr)
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+
 			username, password, _ := r.BasicAuth()
+			usesUsers := authMethodUsesUsers(cfg.Auth.Method)
+			if usesUsers && (username != "" || password != "") {
+				if checkUserCredentials(username, password, cfg.Auth.Users) {
+					lockout.Reset(r.RemoteAddr)
+				} else {
+					lockout.RecordFailure(r.RemoteAddr)
+				}
+			}
+
+			domains := GetDomains(cfg, r.RemoteAddr, username, password)
+			if len(domains) == 0 {
+				addr := sanitize.LogValue(r.RemoteAddr)
+				//nolint:gosec // value is sanitized above
+				log.Printf("client '%s' is not allowed to list any domains", addr)
+				if usesUsers {
+					w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+				}
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
 			values := url.Values{}
-			for domain := range GetDomains(cfg, r.RemoteAddr, username, password) {
+			for domain := range domains {
 				values.Add("list", domain)
 			}
 
@@ -33,6 +62,12 @@ func NewShowDomainsDirectAdmin(cfg *config.Config) func(http.Handler) http.Handl
 			}
 		})
 	}
+}
+
+func authMethodUsesUsers(method string) bool {
+	return method == config.AuthMethodUsers ||
+		method == config.AuthMethodBoth ||
+		method == config.AuthMethodAny
 }
 
 func GetDomains(cfg *config.Config, remoteAddr, username, password string) map[string]struct{} {
@@ -85,12 +120,14 @@ func getDomainsFromAllowedDomains(allowedDomains config.AllowedDomains, remoteAd
 
 func getDomainsFromUsers(users []config.User, username, password string) map[string]struct{} {
 	domains := map[string]struct{}{}
+	if username == "" || password == "" {
+		return domains
+	}
 	for _, user := range users {
-		if user.Username == username && user.Password == password {
+		if constantTimeEqual(user.Username, username)&constantTimeEqual(user.Password, password) == 1 {
 			for _, domain := range user.Domains {
 				domains[domain] = struct{}{}
 			}
-			break
 		}
 	}
 

--- a/pkg/middleware/domains_test.go
+++ b/pkg/middleware/domains_test.go
@@ -2,12 +2,16 @@ package middleware_test
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/config"
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/middleware"
+	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/ratelimit"
 )
 
 var _ = Describe("GetDomains", func() {
@@ -122,4 +126,127 @@ var _ = Describe("GetDomains", func() {
 		Entry("users", config.AuthMethodUsers),
 		Entry("both", config.AuthMethodBoth),
 	)
+})
+
+var _ = Describe("NewShowDomainsDirectAdmin", func() {
+	const (
+		ip       = "127.0.0.1"
+		username = "username"
+		password = "password"
+	)
+
+	var (
+		lockout *ratelimit.Lockout
+		cfg     *config.Config
+	)
+
+	BeforeEach(func() {
+		lockout = ratelimit.NewLockout(3, time.Hour, 15*time.Minute)
+		cfg = &config.Config{
+			Auth: config.Auth{
+				Method: config.AuthMethodUsers,
+				Users: []config.User{{
+					Username: username,
+					Password: password,
+					Domains:  []string{"example.com"},
+				}},
+			},
+		}
+	})
+
+	run := func(username, password string) *httptest.ResponseRecorder {
+		handler := middleware.NewShowDomainsDirectAdmin(cfg, lockout)(nil)
+		req := httptest.NewRequest(http.MethodGet, "/directadmin/CMD_API_SHOW_DOMAINS", http.NoBody)
+		req.RemoteAddr = ip
+		if username != "" || password != "" {
+			req.SetBasicAuth(username, password)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	It("returns 429 when the client is locked out", func() {
+		for range 3 {
+			lockout.RecordFailure(ip)
+		}
+		Expect(lockout.IsBlocked(ip)).To(BeTrue())
+
+		rec := run(username, password)
+		Expect(rec.Code).To(Equal(http.StatusTooManyRequests))
+	})
+
+	It("returns 200 with the domain list when authenticated", func() {
+		rec := run(username, password)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(rec.Body.String()).To(Equal("list=example.com"))
+	})
+
+	It("returns 401 with WWW-Authenticate on bad credentials in users mode", func() {
+		rec := run(username, "wrong")
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+		Expect(rec.Header().Get("WWW-Authenticate")).To(Equal(`Basic realm="Restricted"`))
+		Expect(rec.Body.String()).To(BeEmpty())
+	})
+
+	It("returns 401 without WWW-Authenticate in allowedDomains mode on IP mismatch", func() {
+		cfg.Auth.Method = config.AuthMethodAllowedDomains
+		cfg.Auth.AllowedDomains = config.AllowedDomains{
+			"example.com": []*net.IPNet{{
+				IP:   net.IPv4(10, 0, 0, 1),
+				Mask: net.IPv4Mask(255, 255, 255, 255),
+			}},
+		}
+		rec := run("", "")
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+		Expect(rec.Header().Get("WWW-Authenticate")).To(BeEmpty())
+	})
+
+	It("records a failure on bad credentials when the auth method uses users", func() {
+		run(username, "wrong")
+		run(username, "wrong")
+		Expect(lockout.IsBlocked(ip)).To(BeFalse())
+		run(username, "wrong")
+		Expect(lockout.IsBlocked(ip)).To(BeTrue())
+	})
+
+	It("resets the failure counter after a successful auth", func() {
+		run(username, "wrong")
+		run(username, "wrong")
+
+		rec := run(username, password)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		// Two more bad attempts must still not trigger the lockout because
+		// the counter was reset.
+		run(username, "wrong")
+		run(username, "wrong")
+		Expect(lockout.IsBlocked(ip)).To(BeFalse())
+	})
+
+	It("does not record failures in allowedDomains mode", func() {
+		cfg.Auth.Method = config.AuthMethodAllowedDomains
+		cfg.Auth.AllowedDomains = config.AllowedDomains{}
+
+		for range 5 {
+			run(username, "wrong")
+		}
+		Expect(lockout.IsBlocked(ip)).To(BeFalse())
+	})
+
+	It("does not record a failure when no credentials are supplied", func() {
+		cfg.Auth.Method = config.AuthMethodAny
+		cfg.Auth.AllowedDomains = config.AllowedDomains{}
+
+		for range 5 {
+			run("", "")
+		}
+		Expect(lockout.IsBlocked(ip)).To(BeFalse())
+	})
+
+	It("returns 500 on an invalid auth method", func() {
+		cfg.Auth.Method = "bogus"
+		rec := run(username, password)
+		Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+	})
 })

--- a/pkg/middleware/log.go
+++ b/pkg/middleware/log.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -10,20 +11,38 @@ import (
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/sanitize"
 )
 
+var redactedHeaders = []string{"Authorization", "X-Api-User", "X-Api-Key"}
+
 func LogDebug(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var buf bytes.Buffer
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 		body, err := io.ReadAll(io.TeeReader(r.Body, &buf))
 		if err != nil {
 			log.Printf("failed to read request body: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
+			status := http.StatusInternalServerError
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				status = http.StatusRequestEntityTooLarge
+			}
+			w.WriteHeader(status)
 			return
 		}
 		r.Body = io.NopCloser(&buf)
 		log.Printf("BODY %s", string(body))
-		header := sanitize.LogValue(fmt.Sprintf("%+v", r.Header))
+		header := sanitize.LogValue(fmt.Sprintf("%+v", redactHeader(r.Header)))
 		//nolint:gosec // value is sanitized above
 		log.Printf("HEADER %s", header)
 		next.ServeHTTP(w, r)
 	})
+}
+
+func redactHeader(h http.Header) http.Header {
+	clone := h.Clone()
+	for _, key := range redactedHeaders {
+		if len(clone.Values(key)) > 0 {
+			clone.Set(key, "[REDACTED]")
+		}
+	}
+	return clone
 }

--- a/pkg/middleware/log_test.go
+++ b/pkg/middleware/log_test.go
@@ -1,0 +1,91 @@
+package middleware_test
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/middleware"
+)
+
+var _ = Describe("LogDebug", func() {
+	var (
+		logBuf      *bytes.Buffer
+		prevOutput  io.Writer
+		prevFlags   int
+		innerCalled bool
+		inner       http.Handler
+	)
+
+	BeforeEach(func() {
+		logBuf = &bytes.Buffer{}
+		prevOutput = log.Writer()
+		prevFlags = log.Flags()
+		log.SetOutput(logBuf)
+		log.SetFlags(0)
+
+		innerCalled = false
+		inner = http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			innerCalled = true
+			_, _ = io.ReadAll(r.Body)
+		})
+	})
+
+	AfterEach(func() {
+		log.SetOutput(prevOutput)
+		log.SetFlags(prevFlags)
+	})
+
+	It("redacts sensitive headers", func() {
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{}"))
+		req.Header.Set("Authorization", "Basic c2VjcmV0")
+		req.Header.Set("X-Api-User", "admin")
+		req.Header.Set("X-Api-Key", "supersecret")
+		req.Header.Set("User-Agent", "probe/1.0")
+		rec := httptest.NewRecorder()
+		middleware.LogDebug(inner).ServeHTTP(rec, req)
+
+		Expect(innerCalled).To(BeTrue())
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		logged := logBuf.String()
+		Expect(logged).NotTo(ContainSubstring("c2VjcmV0"))
+		Expect(logged).NotTo(ContainSubstring("supersecret"))
+		Expect(logged).NotTo(ContainSubstring("admin"))
+		Expect(logged).To(ContainSubstring("[REDACTED]"))
+		Expect(logged).To(ContainSubstring("probe/1.0"))
+	})
+
+	It("returns 413 on a body that exceeds the limit", func() {
+		body := strings.Repeat("A", 2<<10) // 2 KB, over the 1 KB limit
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		middleware.LogDebug(inner).ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusRequestEntityTooLarge))
+		Expect(innerCalled).To(BeFalse())
+	})
+
+	It("passes the body through to the next handler", func() {
+		const payload = "hello"
+		var received []byte
+		capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			Expect(err).ToNot(HaveOccurred())
+			received = b
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(payload))
+		rec := httptest.NewRecorder()
+		middleware.LogDebug(capture).ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(string(received)).To(Equal(payload))
+	})
+})

--- a/pkg/ratelimit/limiter.go
+++ b/pkg/ratelimit/limiter.go
@@ -7,7 +7,14 @@ import (
 	"golang.org/x/time/rate"
 )
 
-const limiterSweepInterval = time.Minute
+const (
+	limiterSweepInterval = time.Minute
+	// limiterDefaultMaxBuckets caps memory use when many unique keys are
+	// seen (e.g. under a header-spoofing attack against a trusted proxy).
+	// When full, a new key triggers an eager sweep; if that fails to free
+	// space, the request is rejected.
+	limiterDefaultMaxBuckets = 1 << 16
+)
 
 type bucket struct {
 	limiter  *rate.Limiter
@@ -15,22 +22,24 @@ type bucket struct {
 }
 
 type Limiter struct {
-	mu        sync.Mutex
-	buckets   map[string]*bucket
-	limit     rate.Limit
-	burst     int
-	idle      time.Duration
-	now       func() time.Time
-	lastSweep time.Time
+	mu         sync.Mutex
+	buckets    map[string]*bucket
+	limit      rate.Limit
+	burst      int
+	idle       time.Duration
+	maxBuckets int
+	now        func() time.Time
+	lastSweep  time.Time
 }
 
 func NewLimiter(ratePerSecond float64, burst int, idle time.Duration) *Limiter {
 	return &Limiter{
-		buckets: make(map[string]*bucket),
-		limit:   rate.Limit(ratePerSecond),
-		burst:   burst,
-		idle:    idle,
-		now:     time.Now,
+		buckets:    make(map[string]*bucket),
+		limit:      rate.Limit(ratePerSecond),
+		burst:      burst,
+		idle:       idle,
+		maxBuckets: limiterDefaultMaxBuckets,
+		now:        time.Now,
 	}
 }
 
@@ -39,10 +48,18 @@ func (l *Limiter) Allow(key string) bool {
 	defer l.mu.Unlock()
 
 	now := l.now()
-	l.maybeSweep(now)
+	if l.shouldSweep(now) {
+		l.sweep(now)
+	}
 
 	b, ok := l.buckets[key]
 	if !ok {
+		if len(l.buckets) >= l.maxBuckets {
+			l.sweep(now)
+			if len(l.buckets) >= l.maxBuckets {
+				return false
+			}
+		}
 		b = &bucket{limiter: rate.NewLimiter(l.limit, l.burst)}
 		l.buckets[key] = b
 	}
@@ -50,10 +67,11 @@ func (l *Limiter) Allow(key string) bool {
 	return b.limiter.AllowN(now, 1)
 }
 
-func (l *Limiter) maybeSweep(now time.Time) {
-	if now.Sub(l.lastSweep) < limiterSweepInterval {
-		return
-	}
+func (l *Limiter) shouldSweep(now time.Time) bool {
+	return now.Sub(l.lastSweep) >= limiterSweepInterval
+}
+
+func (l *Limiter) sweep(now time.Time) {
 	l.lastSweep = now
 	for k, b := range l.buckets {
 		if now.Sub(b.lastSeen) > l.idle {

--- a/pkg/ratelimit/limiter_test.go
+++ b/pkg/ratelimit/limiter_test.go
@@ -65,4 +65,33 @@ var _ = Describe("Limiter", func() {
 		Expect(l.Allow("other")).To(BeTrue())
 		Expect(l.buckets).NotTo(HaveKey(ip))
 	})
+
+	Context("when the bucket cap is reached", func() {
+		BeforeEach(func() {
+			l.maxBuckets = 3
+		})
+
+		It("evicts idle buckets before admitting a new key", func() {
+			Expect(l.Allow("a")).To(BeTrue())
+			Expect(l.Allow("b")).To(BeTrue())
+			Expect(l.Allow("c")).To(BeTrue())
+			Expect(l.buckets).To(HaveLen(3))
+
+			now = now.Add(11 * time.Minute)
+			Expect(l.Allow("d")).To(BeTrue())
+			Expect(len(l.buckets)).To(BeNumerically("<=", 3))
+			Expect(l.buckets).To(HaveKey("d"))
+		})
+
+		It("rejects new keys when the cap cannot be freed", func() {
+			Expect(l.Allow("a")).To(BeTrue())
+			Expect(l.Allow("b")).To(BeTrue())
+			Expect(l.Allow("c")).To(BeTrue())
+
+			// All active; sweep cannot free anything.
+			Expect(l.Allow("d")).To(BeFalse())
+			Expect(l.buckets).NotTo(HaveKey("d"))
+			Expect(l.buckets).To(HaveLen(3))
+		})
+	})
 })

--- a/pkg/ratelimit/lockout.go
+++ b/pkg/ratelimit/lockout.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+const (
+	lockoutSweepInterval = time.Minute
+	// lockoutDefaultMaxEntries caps memory use when many unique keys are
+	// seen. When full, a new key triggers an eager sweep; if that fails
+	// to free space, an arbitrary entry is evicted.
+	lockoutDefaultMaxEntries = 1 << 16
+)
+
 type lockoutEntry struct {
 	count       int
 	lastAttempt time.Time
@@ -19,7 +27,9 @@ type Lockout struct {
 	maxAttempts int
 	duration    time.Duration
 	window      time.Duration
+	maxEntries  int
 	now         func() time.Time
+	lastSweep   time.Time
 }
 
 func NewLockout(maxAttempts int, duration, window time.Duration) *Lockout {
@@ -28,6 +38,7 @@ func NewLockout(maxAttempts int, duration, window time.Duration) *Lockout {
 		maxAttempts: maxAttempts,
 		duration:    duration,
 		window:      window,
+		maxEntries:  lockoutDefaultMaxEntries,
 		now:         time.Now,
 	}
 }
@@ -36,11 +47,15 @@ func (l *Lockout) IsBlocked(key string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	now := l.now()
+	if l.shouldSweep(now) {
+		l.sweep(now)
+	}
+
 	e := l.entries[key]
 	if e == nil {
 		return false
 	}
-	now := l.now()
 	if now.Before(e.lockedUntil) {
 		return true
 	}
@@ -56,8 +71,18 @@ func (l *Lockout) RecordFailure(key string) bool {
 	defer l.mu.Unlock()
 
 	now := l.now()
+	if l.shouldSweep(now) {
+		l.sweep(now)
+	}
+
 	e := l.entries[key]
 	if e == nil || e.stale(now, l.window) {
+		if e == nil && len(l.entries) >= l.maxEntries {
+			l.sweep(now)
+			if len(l.entries) >= l.maxEntries {
+				l.evictOne()
+			}
+		}
 		e = &lockoutEntry{}
 		l.entries[key] = e
 	}
@@ -75,6 +100,26 @@ func (l *Lockout) Reset(key string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	delete(l.entries, key)
+}
+
+func (l *Lockout) shouldSweep(now time.Time) bool {
+	return now.Sub(l.lastSweep) >= lockoutSweepInterval
+}
+
+func (l *Lockout) sweep(now time.Time) {
+	l.lastSweep = now
+	for k, e := range l.entries {
+		if e.stale(now, l.window) {
+			delete(l.entries, k)
+		}
+	}
+}
+
+func (l *Lockout) evictOne() {
+	for k := range l.entries {
+		delete(l.entries, k)
+		return
+	}
 }
 
 func (e *lockoutEntry) stale(now time.Time, window time.Duration) bool {

--- a/pkg/ratelimit/lockout_test.go
+++ b/pkg/ratelimit/lockout_test.go
@@ -97,4 +97,37 @@ var _ = Describe("Lockout", func() {
 		Expect(l.IsBlocked(ip)).To(BeFalse())
 		Expect(l.entries).NotTo(HaveKey(ip))
 	})
+
+	Context("when the entry cap is reached", func() {
+		BeforeEach(func() {
+			l.maxEntries = 3
+		})
+
+		It("sweeps stale entries before admitting a new key", func() {
+			l.RecordFailure("a")
+			l.RecordFailure("b")
+			l.RecordFailure("c")
+			Expect(l.entries).To(HaveLen(3))
+
+			now = now.Add(16 * time.Minute)
+			// Bypass shouldSweep by forcing lastSweep recent so the cap
+			// logic has to run the eager sweep itself.
+			l.lastSweep = now
+			l.RecordFailure("d")
+			Expect(l.entries).To(HaveKey("d"))
+			Expect(len(l.entries)).To(BeNumerically("<=", 3))
+		})
+
+		It("evicts an existing entry when sweep cannot free space", func() {
+			l.RecordFailure("a")
+			l.RecordFailure("b")
+			l.RecordFailure("c")
+			Expect(l.entries).To(HaveLen(3))
+
+			l.lastSweep = now
+			l.RecordFailure("d")
+			Expect(l.entries).To(HaveKey("d"))
+			Expect(len(l.entries)).To(BeNumerically("<=", 3))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- **container**: Run as non-root UID 65532 in the scratch image
- **server**: Add HTTP `ReadTimeout` (30s), `WriteTimeout` (30s), and `IdleTimeout` (120s)
- **ratelimit**: Cap in-memory bucket/entry maps to 65536 entries each to prevent unbounded memory growth under IP spoofing; add periodic sweep to both limiter and lockout
- **middleware**: Limit debug log body reads via `MaxBytesReader`; redact `Authorization`, `X-Api-User`, `X-Api-Key` headers before printing
- **middleware**: Apply lockout and constant-time comparison to `CMD_API_SHOW_DOMAINS` user auth
- **config**: Parse `trustedProxies` once at startup into `[]netip.Prefix`, accepting both bare IPs and CIDR ranges; use `prefix.Contains` for matching
- **chore**: Remove stale `//nolint:gosec` directives now flagged by `nolintlint`
- **docs**: Security callout, wildcard subdomain auth, DynDNS2 lockout/nohost note, caller-supplied IP trust model, updated `TRUSTED_PROXIES` description

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` reports 0 issues
- [ ] Verify container runs as UID 65532 (`docker run --rm ... id`)
- [ ] Confirm `TRUSTED_PROXIES=10.0.0.0/8` accepts a forwarded header from `10.1.2.3` and ignores one from `192.168.1.1`
- [ ] Confirm rate limit returns 429 after burst is exhausted
- [ ] Confirm lockout triggers after repeated auth failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)