### PR TITLE
middleware: return after JSON decode error in BindHTTPReq

### DIFF
--- a/pkg/middleware/bind.go
+++ b/pkg/middleware/bind.go
@@ -131,6 +131,7 @@ func BindHTTPReq(next http.Handler) http.Handler {
 		if err := json.NewDecoder(r.Body).Decode(d); err != nil {
 			log.Printf(failedParseRequestFmt, err)
 			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 
 		if d.FQDN == "" {


### PR DESCRIPTION
## Summary
- `BindHTTPReq` in `pkg/middleware/bind.go` was missing a `return` after writing a 400 header on JSON decode failure.
- Execution continued into the `d.FQDN == \"\"` check, which called `http.Error` again and produced a superfluous `WriteHeader` log plus a misleading `fqdn is missing` body.
- Other `Bind*` handlers return correctly in the analogous spot; this aligns `BindHTTPReq` with them.

## Test plan
- [x] `make lint`
- [x] `make test` (18/18 pass)
- [x] `make functest` (68/68 pass)