### PR TITLE
refactor: Drop mutex guarding hcloud record updates

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/config"
@@ -34,9 +33,8 @@ func New(cfg *config.Config) http.Handler {
 	)
 	authorizer := middleware.NewAuthorizer(cfg, lockout)
 
-	m := &sync.Mutex{}
-	updater := update.New(cfg, m)
-	cleaner := clean.New(cfg, m)
+	updater := update.New(cfg)
+	cleaner := clean.New(cfg)
 
 	limiter := ratelimit.NewLimiter(cfg.RateLimit.RPS, cfg.RateLimit.Burst, time.Duration(cfg.RateLimit.IdleSeconds)*time.Second)
 	rl := middleware.NewRateLimit(limiter, middleware.RateLimitExceeded)

--- a/pkg/middleware/clean/clean.go
+++ b/pkg/middleware/clean/clean.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/config"
@@ -12,8 +11,8 @@ import (
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/middleware/clean/cloud"
 )
 
-func New(cfg *config.Config, m *sync.Mutex) func(http.Handler) http.Handler {
-	c := cloud.New(cfg, m)
+func New(cfg *config.Config) func(http.Handler) http.Handler {
+	c := cloud.New(cfg)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/middleware/clean/cloud/cloud.go
+++ b/pkg/middleware/clean/cloud/cloud.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"context"
-	"sync"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 
@@ -14,22 +13,16 @@ import (
 type cleaner struct {
 	cfg    *config.Config
 	client *hcloud.Client
-	m      *sync.Mutex
 }
 
-func New(cfg *config.Config, m *sync.Mutex) *cleaner {
+func New(cfg *config.Config) *cleaner {
 	return &cleaner{
 		cfg:    cfg,
 		client: hetzner.NewHCloudClient(cfg),
-		m:      m,
 	}
 }
 
 func (u *cleaner) Clean(ctx context.Context, reqData *data.ReqData) error {
-	// Ensure only one simultaneous update sequence
-	u.m.Lock()
-	defer u.m.Unlock()
-
 	rrSetType, err := hetzner.RRSetTypeFromString(reqData.Type)
 	if err != nil {
 		return err

--- a/pkg/middleware/update/cloud/cloud.go
+++ b/pkg/middleware/update/cloud/cloud.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"context"
-	"sync"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 
@@ -14,22 +13,16 @@ import (
 type updater struct {
 	cfg    *config.Config
 	client *hcloud.Client
-	m      *sync.Mutex
 }
 
-func New(cfg *config.Config, m *sync.Mutex) *updater {
+func New(cfg *config.Config) *updater {
 	return &updater{
 		cfg:    cfg,
 		client: hetzner.NewHCloudClient(cfg),
-		m:      m,
 	}
 }
 
 func (u *updater) Update(ctx context.Context, reqData *data.ReqData) error {
-	// Ensure only one simultaneous update sequence
-	u.m.Lock()
-	defer u.m.Unlock()
-
 	rrSetType, err := hetzner.RRSetTypeFromString(reqData.Type)
 	if err != nil {
 		return err

--- a/pkg/middleware/update/update.go
+++ b/pkg/middleware/update/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/config"
@@ -12,8 +11,8 @@ import (
 	"github.com/0xfelix/hetzner-dnsapi-proxy/pkg/middleware/update/cloud"
 )
 
-func New(cfg *config.Config, m *sync.Mutex) func(http.Handler) http.Handler {
-	u := cloud.New(cfg, m)
+func New(cfg *config.Config) func(http.Handler) http.Handler {
+	u := cloud.New(cfg)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- The global `sync.Mutex` shared by the updater and cleaner was a holdover from the old Hetzner DNS API code, which needed multiple sequential HTTP calls (fetch zones, fetch records, then update) per request.
- With the hcloud API, this proxy only forwards a request to Hetzner; the API itself is the source of truth and handles concurrency, so serializing every update in-process adds no real correctness guarantee and unnecessarily limits throughput across unrelated zones.
- Removed the mutex and its plumbing from `app`, `update`, and `clean` (and the `cloud` sub-packages).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`